### PR TITLE
fix: helptext for 'inspect version' and 'providers inspect'

### DIFF
--- a/src/llama_stack_client/lib/cli/inspect/version.py
+++ b/src/llama_stack_client/lib/cli/inspect/version.py
@@ -9,7 +9,7 @@ from ..common.utils import handle_client_errors
 @click.pass_context
 @handle_client_errors("inspect version")
 def inspect_version(ctx):
-    """Show available providers on distribution endpoint"""
+    """Show Llama Stack version on distribution endpoint"""
     client = ctx.obj["client"]
     console = Console()
     version_response = client.inspect.version()

--- a/src/llama_stack_client/lib/cli/providers/inspect.py
+++ b/src/llama_stack_client/lib/cli/providers/inspect.py
@@ -10,7 +10,7 @@ from ..common.utils import handle_client_errors
 @click.pass_context
 @handle_client_errors("inspect providers")
 def inspect_provider(ctx, provider_id):
-    """Show available providers on distribution endpoint"""
+    """Show specific provider configuration on distribution endpoint"""
     client = ctx.obj["client"]
     console = Console()
 


### PR DESCRIPTION
Supersedes https://github.com/meta-llama/llama-stack-client-python/pull/251